### PR TITLE
Simplify configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ Session.vim
 /.venv
 /.coverage
 /htmlcov
+/secret.txt
+/static
 
 __pycache__
 .*.swp

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install -r requirements.txt
 
 Edit the [settings file](etesync_server/settings.py). Please refer to the
 [Django deployment
-checklist](https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/)
+checklist](https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/)
 for full instructions on how to configure a Django app for production. Some
 particular settings that should be edited are:
   * [`ALLOWED_HOSTS`](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-ALLOWED_HOSTS)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,20 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Set the django ```SECRET_KEY``` and ```ALLOWED_HOSTS``` in [the settings file](etesync_server/settings.py).
-For more information on these please refer to the [django deployment checklist](https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/).
+Edit the [settings file](etesync_server/settings.py). Please refer to the
+[Django deployment
+checklist](https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/)
+for full instructions on how to configure a Django app for production. Some
+particular settings that should be edited are:
+  * [`ALLOWED_HOSTS`](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-ALLOWED_HOSTS)
+    -- this is the list of host/domain names or addresses on which the app
+will be served
+  * [`DEBUG`](https://docs.djangoproject.com/en/1.11/ref/settings/#debug)
+    -- handy for debugging, set to `False` for production
+  * [`SECRET_KEY`](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-SECRET_KEY)
+    -- an ephemeral secret used for various cryptographic signing and token
+generation purposes. See below for how default configuration of
+`SECRET_KEY` works for this project.
 
 Now you can initialise our django app
 
@@ -49,6 +61,26 @@ and create a non-privileged user that you can use.
 That's it!
 
 Now all that's left is to open the EteSync app, add an account, and set your custom server address under the "advance" section.
+
+# `SECRET_KEY` and `secret.txt`
+
+The default configuration creates a file “`secret.txt`” in the project’s
+base directory, which is used as the value of the Django `SECRET_KEY`
+setting. You can revoke this key by deleting the `secret.txt` file and the
+next time the app is run, a new one will be generated. Make sure you keep
+the `secret.txt` file secret (don’t accidentally commit it to version
+control, exclude it from your backups, etc.). If you want to change to a
+more secure system for storing secrets, edit `etesync_server/settings.py`
+and implement your own method for setting `SECRET_KEY` (remove the line
+where it uses the `get_secret_from_file` function).  Read the Django docs
+for more information about the `SECRET_KEY` and its uses.
+
+# Updating
+
+Inside the virtualenv, run `pip install -U -r requirements.txt` to update
+dependencies to latest compatible versions of Django and
+djangorestframework (it will only update to latest patch level which should
+be API-compatible).
 
 # Supporting EteSync
 

--- a/etesync_server/settings.py
+++ b/etesync_server/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 """
 
 import os
-from django.core.management import utils
+from .utils import get_secret_from_file
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -21,15 +21,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY_FILE = os.path.join(BASE_DIR, "secret.txt")
-
-try:
-    with open(SECRET_KEY_FILE, "r") as f:
-        SECRET_KEY = f.read().strip()
-except EnvironmentError:
-    with open(SECRET_KEY_FILE, "w") as f:
-        SECRET_KEY = utils.get_random_secret_key()
-        f.write(SECRET_KEY)
+# See secret.py for how this is generated; uses a file 'secret.txt' in the root
+# directory
+SECRET_KEY = get_secret_from_file(os.path.join(BASE_DIR, "secret.txt"))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False

--- a/etesync_server/settings.py
+++ b/etesync_server/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 """
 
 import os
+from django.core.management import utils
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -20,7 +21,15 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ''
+SECRET_KEY_FILE = os.path.join(BASE_DIR, "secret.txt")
+
+try:
+    with open(SECRET_KEY_FILE, "r") as f:
+        SECRET_KEY = f.read().strip()
+except EnvironmentError:
+    with open(SECRET_KEY_FILE, "w") as f:
+        SECRET_KEY = utils.get_random_secret_key()
+        f.write(SECRET_KEY)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False

--- a/etesync_server/utils.py
+++ b/etesync_server/utils.py
@@ -1,0 +1,11 @@
+from django.core.management import utils
+
+def get_secret_from_file(path):
+    try:
+        with open(path, "r") as f:
+            return f.read().strip()
+    except EnvironmentError:
+        with open(path, "w") as f:
+            secret_key = utils.get_random_secret_key()
+            f.write(secret_key)
+            return secret_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==1.11.7
-djangorestframework==3.7.1
+Django>=1.11,<1.11.999
+djangorestframework>=3.7,<3.7.999
 drf-nested-routers==0.90.0
-pytz==2017.3
+pytz
 git+git://github.com/etesync/journal-manager@v0.4.1


### PR DESCRIPTION
Hi,
I've included here some minor things I did when playing around with a test deployment. My aim is to simplify set up. Not sure if you will want to merge them, but here they are anyway.
The main thing is using a secret.txt file to store the `SECRET_KEY`, along with a utility function to generate it if its not there. I've documented this in the readme. This is of course relevant to any Django app, not EteSync in particular, but I think there's value in making it easy to just download and run for people trying it out. I have little experience deploying Django apps but I read a few answers on StackOverflow suggesting to do it this way. It seems the same or marginally more secure than the default when you create a new Django project, embedding it in the settings.py file.
I've also changed the requirements.txt so it can be used to update to the latest patch-level versions (according to the Django docs, patch-level releases should be compatible). I removed the version pin altogether for pytz as its mainly just a list of timezones and should not break if updated (I think?).
Its up to you whether the requirement on the `etesync/journal-manager` git repo could also be pinned to a range of versions; I did not change that one as I can see you are working on 0.5.
Thanks again for making this open source, its a great project.