### PR TITLE
Use external config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Edit the [settings file](etesync_server/settings.py). Please refer to the
-[Django deployment
-checklist](https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/)
-for full instructions on how to configure a Django app for production. Some
-particular settings that should be edited are:
+If you are familiar with Django you can just edit the [settings file](etesync_server/settings.py)
+according to the [Django deployment checklist](https://docs.djangoproject.com/en/1.11/howto/deployment/checklist)
+if you are not, we also provide a simple [configuration file](etesync-server.ini)
+for easy deployment which you can use. You can either edit the provided file or
+create one in `/etc/etesync-server`.
+
+Some particular settings that should be edited are:
   * [`ALLOWED_HOSTS`](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-ALLOWED_HOSTS)
     -- this is the list of host/domain names or addresses on which the app
 will be served

--- a/etesync-server.ini
+++ b/etesync-server.ini
@@ -1,0 +1,10 @@
+[global]
+secret_file = secret.txt
+debug = false
+
+[allowed_hosts]
+;allowed_host1 = host1.tld
+
+[database]
+engine = django.db.backends.sqlite3
+name = db.sqlite3

--- a/etesync_server/settings.py
+++ b/etesync_server/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
 import os
+import configparser
 from .utils import get_secret_from_file
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -29,6 +30,34 @@ SECRET_FILE = os.path.join(BASE_DIR, "secret.txt")
 DEBUG = False
 
 ALLOWED_HOSTS = []
+
+# Database
+# https://docs.djangoproject.com/en/2.0/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.environ.get('ETESYNC_DB_PATH',
+                               os.path.join(BASE_DIR, 'db.sqlite3')),
+    }
+}
+
+
+
+# Define where to find configuration files
+config_locations = ['etesync-server.ini', '/etc/etesync-server/etesync-server.ini']
+# Use config file if present
+if any(os.path.isfile(x) for x in config_locations):
+    config = configparser.ConfigParser()
+    config.read(config_locations)
+
+    SECRET_FILE = config['global']['secret_file']
+
+    DEBUG = config['global'].getboolean('debug')
+
+    ALLOWED_HOSTS = [y for x, y in config.items('allowed_hosts')]
+
+    DATABASES = { 'default': { x.upper(): y for x, y in config.items('database') } }
 
 
 # Application definition
@@ -76,18 +105,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'etesync_server.wsgi.application'
-
-
-# Database
-# https://docs.djangoproject.com/en/2.0/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.environ.get('ETESYNC_DB_PATH',
-                               os.path.join(BASE_DIR, 'db.sqlite3')),
-    }
-}
 
 
 # Password validation


### PR DESCRIPTION
As discussed on IRC, this makes the server use an external .ini configuration file without removing the ability to use Django style configuration in the settings.py file.

The .ini file can be located either in /etc/etesync-server/etesync-server.ini or directly in the top-level directory of the project (more locations can be added easily).

An example etesync-server.ini is provided, that should copy the default settings used so far.